### PR TITLE
C02 to CO2

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -83,7 +83,7 @@ export default function Main() {
               {carbonIntensity}
             </Typography>
             <Typography style={{ display: "inline-block" }}>
-              gC02/kWh
+              gCO2/kWh
             </Typography>
             <Graph
               monthData={dailyCarbonByMonth ?? null}

--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -83,7 +83,7 @@ export default function Main() {
               {carbonIntensity}
             </Typography>
             <Typography style={{ display: "inline-block" }}>
-              gCO2/kWh
+              gCO₂/kWh
             </Typography>
             <Graph
               monthData={dailyCarbonByMonth ?? null}

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -145,7 +145,7 @@ export default function Graph(props: GraphProps) {
         interval="preserveStartEnd"
       />
       <YAxis
-        label={{ value: "gC02/kWh", angle: -90, position: "insideLeft" }}
+        label={{ value: "gCO2/kWh", angle: -90, position: "insideLeft" }}
         domain={[0, 900]}
       />
       <Tooltip content={<CustomTooltip />} />

--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -145,7 +145,7 @@ export default function Graph(props: GraphProps) {
         interval="preserveStartEnd"
       />
       <YAxis
-        label={{ value: "gCO2/kWh", angle: -90, position: "insideLeft" }}
+        label={{ value: "gCO₂/kWh", angle: -90, position: "insideLeft" }}
         domain={[0, 900]}
       />
       <Tooltip content={<CustomTooltip />} />

--- a/src/components/graph/Tooltip.tsx
+++ b/src/components/graph/Tooltip.tsx
@@ -49,7 +49,7 @@ export default function CustomTooltip({ payload, label, active }: any) {
           >
             {Math.round(data)}
           </Typography>
-          gCO2/kWh
+          gCO₂/kWh
         </div>
       ) : (
         <div></div>

--- a/src/components/graph/Tooltip.tsx
+++ b/src/components/graph/Tooltip.tsx
@@ -49,7 +49,7 @@ export default function CustomTooltip({ payload, label, active }: any) {
           >
             {Math.round(data)}
           </Typography>
-          gC02/kWh
+          gCO2/kWh
         </div>
       ) : (
         <div></div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "The CO2 emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
+  "theCarbonIs": "The CO&#8322; emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
   "months": [
     "January",
     "February",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero", "japan"],
-    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh",
-    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh",
-    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh"
+    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh",
+    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh",
+    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh"
   },
   "graph": {
     "average": "Average",
@@ -68,7 +68,7 @@
       "title": "How is the Carbon Intensity Calculated?",
       "paragraph": [
         "The carbon intensity is calculated for a given period by figuring out the proportion of energy generation that came from each fuel type.",
-        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 gCO2/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 gCO2/kWh.",
+        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 gCO&#8322;/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 gCO&#8322;/kWh.",
         "This isn't perfect, as each generating plant is likely to have a different carbon intensity factor, which changes over the course of the year.",
         "Even more troublesome, the data used by this tool - which is provided by Japanese utility companies - considers all Fossil Fuels under one heading 'Thermal Generation', so with the data, we cannot tell what kinds of fuel were being burned during that period.",
         "Currently, we use other reporting and sources to try and figure out the average contribution of each fuel source.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "The CO&#8322; emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
+  "theCarbonIs": "The CO₂ emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
   "months": [
     "January",
     "February",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero", "japan"],
-    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh",
-    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh",
-    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO&#8322;/kWh"
+    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO₂/kWh",
+    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO₂/kWh",
+    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO₂/kWh"
   },
   "graph": {
     "average": "Average",
@@ -68,7 +68,7 @@
       "title": "How is the Carbon Intensity Calculated?",
       "paragraph": [
         "The carbon intensity is calculated for a given period by figuring out the proportion of energy generation that came from each fuel type.",
-        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 gCO&#8322;/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 gCO&#8322;/kWh.",
+        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 gCO₂/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 gCO₂/kWh.",
         "This isn't perfect, as each generating plant is likely to have a different carbon intensity factor, which changes over the course of the year.",
         "Even more troublesome, the data used by this tool - which is provided by Japanese utility companies - considers all Fossil Fuels under one heading 'Thermal Generation', so with the data, we cannot tell what kinds of fuel were being burned during that period.",
         "Currently, we use other reporting and sources to try and figure out the average contribution of each fuel source.",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "The C02 emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
+  "theCarbonIs": "The CO2 emitted from Electricity Generation supplied by <utilityMenu></utilityMenu> right now is (probably):",
   "months": [
     "January",
     "February",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero", "japan"],
-    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gC02/kWh",
-    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gC02/kWh",
-    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gC02/kWh"
+    "twitter": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh",
+    "facebook": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh",
+    "linkedin": "The carbon intensity in the {{utility}} supply area is currently {{carbonIntensity}}gCO2/kWh"
   },
   "graph": {
     "average": "Average",
@@ -68,7 +68,7 @@
       "title": "How is the Carbon Intensity Calculated?",
       "paragraph": [
         "The carbon intensity is calculated for a given period by figuring out the proportion of energy generation that came from each fuel type.",
-        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 C02/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 C02/kWh.",
+        "This proportion is then multiplied by the Carbon Intensity for that fuel type, for example, the carbon intensity factor for coal is 937 gCO2/kWh with Combined Cycle Gas Turbines (CCGT) having a factor of 394 gCO2/kWh.",
         "This isn't perfect, as each generating plant is likely to have a different carbon intensity factor, which changes over the course of the year.",
         "Even more troublesome, the data used by this tool - which is provided by Japanese utility companies - considers all Fossil Fuels under one heading 'Thermal Generation', so with the data, we cannot tell what kinds of fuel were being burned during that period.",
         "Currently, we use other reporting and sources to try and figure out the average contribution of each fuel source.",

--- a/src/translations/jp.json
+++ b/src/translations/jp.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているCO2の量は(推定値):",
+  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているCO&#8322;の量は(推定値):",
   "months": [
     "1月",
     "2月",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero"],
-    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh",
-    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh",
-    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh"
+    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh",
+    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh",
+    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh"
   },
   "graph": {
     "average": "平均",
@@ -68,7 +68,7 @@
       "title": "炭素強度をどう割り出しているか？",
       "paragraph": [
         "炭素強度は、各燃料タイプから発生するエネルギー生成の割合に燃料タイプごとの炭素強度係数を乗算ことにより、特定の期間について計算されます。",
-        "例えば、石炭の炭素強度係数は394 gCO2/kWh、複合サイクルガスタービン（CCGT）は937 gCO2/kWhです。",
+        "例えば、石炭の炭素強度係数は394 gCO&#8322;/kWh、複合サイクルガスタービン（CCGT）は937 gCO&#8322;/kWhです。",
         "これらは完璧ではありません。各発電プラントの炭素強度係数は、年間を通じて変化する可能性が高いためです。",
         "さらに厄介なのは、電力会社が提供するこのデータは、「火力発電」という1つの見出しの下ですべて考慮しているため、その期間にどのような燃料が燃やされていたのかが分かりません。",
         "現在、私たちは他のレポートや情報源を使用して、各燃料源の平均的な寄与度を算出しています。",

--- a/src/translations/jp.json
+++ b/src/translations/jp.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているC02の量は(推定値):",
+  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているCO2の量は(推定値):",
   "months": [
     "1月",
     "2月",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero"],
-    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gC02/kWh",
-    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gC02/kWh",
-    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gC02/kWh"
+    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh",
+    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh",
+    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO2/kWh"
   },
   "graph": {
     "average": "平均",
@@ -68,7 +68,7 @@
       "title": "炭素強度をどう割り出しているか？",
       "paragraph": [
         "炭素強度は、各燃料タイプから発生するエネルギー生成の割合に燃料タイプごとの炭素強度係数を乗算ことにより、特定の期間について計算されます。",
-        "例えば、石炭の炭素強度係数は394 C02/kWh、複合サイクルガスタービン（CCGT）は937 C02/kWhです。",
+        "例えば、石炭の炭素強度係数は394 gCO2/kWh、複合サイクルガスタービン（CCGT）は937 gCO2/kWhです。",
         "これらは完璧ではありません。各発電プラントの炭素強度係数は、年間を通じて変化する可能性が高いためです。",
         "さらに厄介なのは、電力会社が提供するこのデータは、「火力発電」という1つの見出しの下ですべて考慮しているため、その期間にどのような燃料が燃やされていたのかが分かりません。",
         "現在、私たちは他のレポートや情報源を使用して、各燃料源の平均的な寄与度を算出しています。",

--- a/src/translations/jp.json
+++ b/src/translations/jp.json
@@ -1,5 +1,5 @@
 {
-  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているCO&#8322;の量は(推定値):",
+  "theCarbonIs": "今現在 <utilityMenu></utilityMenu> の発電所から排出されているCO₂の量は(推定値):",
   "months": [
     "1月",
     "2月",
@@ -40,9 +40,9 @@
   },
   "social": {
     "hashtags": ["renewableenergy", "climateaction", "netzero"],
-    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh",
-    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh",
-    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO&#8322;/kWh"
+    "twitter": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO₂/kWh",
+    "facebook": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO₂/kWh",
+    "linkedin": "今現在{{utility}}の発電所から排出されているC02の量は{{carbonIntensity}}gCO₂/kWh"
   },
   "graph": {
     "average": "平均",
@@ -68,7 +68,7 @@
       "title": "炭素強度をどう割り出しているか？",
       "paragraph": [
         "炭素強度は、各燃料タイプから発生するエネルギー生成の割合に燃料タイプごとの炭素強度係数を乗算ことにより、特定の期間について計算されます。",
-        "例えば、石炭の炭素強度係数は394 gCO&#8322;/kWh、複合サイクルガスタービン（CCGT）は937 gCO&#8322;/kWhです。",
+        "例えば、石炭の炭素強度係数は394 gCO₂/kWh、複合サイクルガスタービン（CCGT）は937 gCO₂/kWhです。",
         "これらは完璧ではありません。各発電プラントの炭素強度係数は、年間を通じて変化する可能性が高いためです。",
         "さらに厄介なのは、電力会社が提供するこのデータは、「火力発電」という1つの見出しの下ですべて考慮しているため、その期間にどのような燃料が燃やされていたのかが分かりません。",
         "現在、私たちは他のレポートや情報源を使用して、各燃料源の平均的な寄与度を算出しています。",


### PR DESCRIPTION
Tidies up a few places where "CO<sub>2</sub>" was written as "C0<sub>2</sub>" (i.e. with zero char) and where grams "g" was missing from the units.

It might be possible to get the subscript 2 to display correctly by using [this](https://www.fileformat.info/info/unicode/char/2082/index.htm) unicode char. For easy roll-back I'll put two separate commits through with edits for these now, as the chance of something breaking is non-zero!