### PR TITLE
Add UK Average Intensity to Graph

### DIFF
--- a/src/components/graph/Graph.tsx
+++ b/src/components/graph/Graph.tsx
@@ -29,6 +29,8 @@ const useStyles = makeStyles({
 });
 
 const INDUSTRY_TARGET_2030 = 370;
+// From https://www.nationalgrideso.com/news/record-breaking-2020-becomes-greenest-year-britains-electricity
+const UK_AVERAGE_2020 = 181
 
 interface GraphProps {
   monthData: DailyCarbonDataByMonth[];
@@ -59,11 +61,17 @@ export default function Graph(props: GraphProps) {
       name: String(t("graph.forecast")),
     },
     target: {
-      color: "green",
+      color: "red",
       type: "line",
       strokeDasharray: "6 6",
       name: String(t("graph.targetLine")),
     },
+    averageUK: {
+      color: "green",
+      type: "line",
+      strokeDasharray: "6 6",
+      name: String(t("graph.averageUKLine")),
+    }
   };
 
   const legendPayload: ReadonlyArray<any> = [
@@ -88,6 +96,15 @@ export default function Graph(props: GraphProps) {
       },
       color: lineInfo.target.color,
     },
+    {
+      value: lineInfo.averageUK.name,
+      id: 5,
+      type: "plainline",
+      payload: {
+        strokeDasharray: lineInfo.averageUK.strokeDasharray,
+      },
+      color: lineInfo.averageUK.color,
+    },
   ];
 
   if (Object.keys(props.monthData).length < 12) {
@@ -98,9 +115,10 @@ export default function Graph(props: GraphProps) {
   let data = props.monthData[monthChoice].data;
 
   data = data.map((dp: any, i: number) => {
-    // Add 2030 target
+    // Add 2030 target and UK average
     const newDP: any = {
       target2030: INDUSTRY_TARGET_2030,
+      averageUK2020: UK_AVERAGE_2020,
       forecast: props.forecastData[i]?.forecast_value,
       average: dp.carbon_intensity,
       hour: dp.hour,
@@ -134,6 +152,14 @@ export default function Graph(props: GraphProps) {
         type="monotone"
         dataKey="target2030"
         stroke={lineInfo.target.color}
+        strokeDasharray="3 3"
+        dot={false}
+      />
+      <Line
+        name={lineInfo.target.name}
+        type="monotone"
+        dataKey="averageUK2020"
+        stroke={lineInfo.averageUK.color}
         strokeDasharray="3 3"
         dot={false}
       />

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -51,7 +51,8 @@
     "averageLine": "Average",
     "forecastLine": "Forecast",
     "compareLine": "Compared Month",
-    "targetLine": "2030 Target"
+    "targetLine": "2030 Target",
+    "averageUKLine": "UK Average 2020"
   },
   "carbonGraphTitle": "Today's Carbon Intensity Forecast, compared with 4-year average data for <monthMenu></monthMenu>",
   "explanation": {

--- a/src/translations/jp.json
+++ b/src/translations/jp.json
@@ -51,7 +51,8 @@
     "averageLine": "平均",
     "forecastLine": "予報",
     "compareLine": "比較月",
-    "targetLine": "2030までの目標"
+    "targetLine": "2030までの目標",
+    "averageUKLine": "イギリスの2020平均"
   },
   "carbonGraphTitle": "今日の炭素強度予報と<monthMenu></monthMenu>の過去4年の平均",
   "explanation": {


### PR DESCRIPTION
I wanted to add a comparison to where Japan is compared to another OPEC country - the UK is a good target for Japan to be comparing themselves to in my opinion.
This will help draw a comparison between Japan's 2030 target and where other countries are **literally right now** to help show how much work Japan still needs to do in decarbonization. 

<img width="567" alt="image" src="https://user-images.githubusercontent.com/25011388/134791191-6ef266b1-62e5-4e02-ae4a-75a3a654b6ff.png">

- Adds a line for the average Carbon intensity in the UK for 2020 (sourced from this post from NGESO https://www.nationalgrideso.com/news/record-breaking-2020-becomes-greenest-year-britains-electricity) at 181
- Changes target line to `red` and uses `green` for the new UK line
- Adds translations